### PR TITLE
Add GET /latestMeasurement Endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1067,8 +1067,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1089,14 +1088,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1111,20 +1108,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1241,8 +1235,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1254,7 +1247,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1269,7 +1261,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1277,14 +1268,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1303,7 +1292,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1384,8 +1372,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1397,7 +1384,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1483,8 +1469,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1520,7 +1505,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1540,7 +1524,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1584,14 +1567,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2181,6 +2181,11 @@
         }
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "body-parser": "^1.18.3",
     "cheerio": "^1.0.0-rc.3",
     "express": "^4.16.4",
+    "moment": "^2.24.0",
     "request": "^2.88.0",
     "request-promise": "^4.2.4"
   },

--- a/scraper.js
+++ b/scraper.js
@@ -39,7 +39,7 @@ async function getLatestMeasurements(measuringPointUrl, requestedMeasurementType
     return rp(measuringPointUrl)
         .then(async html => {
 
-            let needsAllMeasurements = requestedMeasurementTypes.length == 0;
+            //let needsAllMeasurements = requestedMeasurementTypes.length == 0;
             // We need latitude, longitude, (height), timestamp, measurements and measurementTypes.
             const measurementTypesTableRow = $('thead', html).children().first().children();
             const numberOfMeasurementsTypes = $(measurementTypesTableRow).length;
@@ -61,18 +61,14 @@ async function getLatestMeasurements(measuringPointUrl, requestedMeasurementType
             measurementValues["latitude"] = coordinates.lat;
             measurementValues["longitude"] = coordinates.lng;
 
-            requestedMeasurementTypes.forEach((i, element) => {
-                measurementValues[i] = null;
-            });
-
             $(dateTableCell).nextAll().each((i, element) => {
                 const measurement = $(element).contents().not($(element).children()).text().trim();
-                const measurementUnit = $(measurementTypesTableRow[i]).children().first().text();
-                let isRequestedMeasurementUnit = requestedMeasurementTypes.includes(measurementUnit);
+                const measurementType = $(measurementTypesTableRow[i]).children().first().text();
+                let isRequestedMeasurementUnit = requestedMeasurementTypes.includes(measurementType);
 
-                if ((needsAllMeasurements) || (isRequestedMeasurementUnit)) {
-                    if (measurementUnit !== '') {
-                        measurementValues[measurementUnit] = measurement;
+                if (isRequestedMeasurementUnit) {
+                    if (measurementType !== '') {
+                        measurementValues["measurement"] = measurement;
                     }
                 }
             });

--- a/scraper.js
+++ b/scraper.js
@@ -39,7 +39,6 @@ async function getLatestMeasurements(measuringPointUrl, requestedMeasurementType
     return rp(measuringPointUrl)
         .then(async html => {
 
-            //let needsAllMeasurements = requestedMeasurementTypes.length == 0;
             // We need latitude, longitude, (height), timestamp, measurements and measurementTypes.
             const measurementTypesTableRow = $('thead', html).children().first().children();
             const numberOfMeasurementsTypes = $(measurementTypesTableRow).length;

--- a/scraper.js
+++ b/scraper.js
@@ -3,6 +3,7 @@ const $ = require('cheerio');
 const axios = require('axios');
 const querystring = require('querystring');
 const config = require('./config.json');
+const moment = require('moment');
 
 const API_KEY_GOOGLE = config['API_KEY_GOOGLE'];
 
@@ -21,13 +22,16 @@ async function scrape(requestedMeasurementTypes) {
             }
 
             // Now we can get the measurements from the measuring points.            
-            await Promise.all(urlsMeasuringPoints.map(async measuringPointUrl => {
-                data.push(await getLatestMeasurements(baseUrl + measuringPointUrl, requestedMeasurementTypes));
-            }));
+            await Promise
+                    .all(urlsMeasuringPoints
+                    .map(async measuringPointUrl => {
+                        data.push(await getLatestMeasurements(baseUrl + measuringPointUrl, requestedMeasurementTypes));
+                    }));
+
             return data;
         })
         .catch((err) => {
-            console.log(err);
+            return [];
         });
 }
 
@@ -45,7 +49,10 @@ async function getLatestMeasurements(measuringPointUrl, requestedMeasurementType
             var measurementValues = {};
 
             let timestamp = $(dateTableCell).children().first().text();
-            //timestamp = new Date(timestamp).toLocaleString();
+
+            let m = moment(timestamp, 'DD.MM.YYYY HH:mm', 'de');
+
+            timestamp = new Date(m.toISOString()).toLocaleString();
 
             const address = $('dt:contains("Adresse:")', html).next().text();
             const coordinates = await getCoordinatesFromAddress(address);
@@ -73,7 +80,7 @@ async function getLatestMeasurements(measuringPointUrl, requestedMeasurementType
             return measurementValues;
         })
         .catch((err) => {
-            console.log(err);
+            return {};
         });
 }
 

--- a/scraper.js
+++ b/scraper.js
@@ -8,7 +8,7 @@ const API_KEY_GOOGLE = config['API_KEY_GOOGLE'];
 
 const baseUrl = 'https://luftdaten.berlin.de';
 
-async function scrape() {
+async function scrape(requestedMeasurementTypes) {
     // First we have to get the URLs of the measuering points of BLUME.
     return rp(baseUrl + '/lqi')
         .then(async html => {
@@ -20,9 +20,9 @@ async function scrape() {
                 urlsMeasuringPoints.push($('a.lmn-button', html)[i].attribs.href);
             }
 
-            // Now we can get the measurements from the measuring points.
+            // Now we can get the measurements from the measuring points.            
             await Promise.all(urlsMeasuringPoints.map(async measuringPointUrl => {
-                data.push(await getLatestMeasurements(baseUrl + measuringPointUrl));
+                data.push(await getLatestMeasurements(baseUrl + measuringPointUrl, requestedMeasurementTypes));
             }));
             return data;
         })
@@ -31,45 +31,46 @@ async function scrape() {
         });
 }
 
-async function getLatestMeasurements(measuringPointUrl) {
+async function getLatestMeasurements(measuringPointUrl, requestedMeasurementTypes) {
     return rp(measuringPointUrl)
         .then(async html => {
+
+            let needsAllMeasurements = requestedMeasurementTypes.length == 0;
             // We need latitude, longitude, (height), timestamp, measurements and measurementTypes.
             const measurementTypesTableRow = $('thead', html).children().first().children();
             const numberOfMeasurementsTypes = $(measurementTypesTableRow).length;
             const latestMeasurementTableRow = $('tbody', html).children().first();
             const dateTableCell = $(latestMeasurementTableRow).children().first();
 
-            const measurementTypes = [];
-            for (let i = 1; i < numberOfMeasurementsTypes; i++) {
-                const currentTableCell = $(measurementTypesTableRow[i]);
-                measurementTypes.push($(currentTableCell).children().first().text());
-            }
-
-            const measurements = [];
-            $(dateTableCell).nextAll().each((i, element) => {
-                const measurementWithoutUnit = $(element).contents().not($(element).children()).text().trim();
-                measurements.push(measurementWithoutUnit);
-            });
+            var measurementValues = {};
 
             let timestamp = $(dateTableCell).children().first().text();
-            timestamp = new Date(timestamp).toLocaleString();
+            //timestamp = new Date(timestamp).toLocaleString();
 
             const address = $('dt:contains("Adresse:")', html).next().text();
             const coordinates = await getCoordinatesFromAddress(address);
 
-            const latestMeasurements = {
-                'timestamp': timestamp,
-                'latitude': coordinates.lat,
-                'longitude': coordinates.lng
-            }
-            measurementTypes.forEach((measurementType, i) => {
-                if (measurementType !== '') {
-                    latestMeasurements[measurementType] = measurements[i];
+            measurementValues["timestamp"] = timestamp;
+            measurementValues["latitude"] = coordinates.lat;
+            measurementValues["longitude"] = coordinates.lng;
+
+            requestedMeasurementTypes.forEach((i, element) => {
+                measurementValues[i] = null;
+            });
+
+            $(dateTableCell).nextAll().each((i, element) => {
+                const measurement = $(element).contents().not($(element).children()).text().trim();
+                const measurementUnit = $(measurementTypesTableRow[i]).children().first().text();
+                let isRequestedMeasurementUnit = requestedMeasurementTypes.includes(measurementUnit);
+
+                if ((needsAllMeasurements) || (isRequestedMeasurementUnit)) {
+                    if (measurementUnit !== '') {
+                        measurementValues[measurementUnit] = measurement;
+                    }
                 }
             });
 
-            return latestMeasurements;
+            return measurementValues;
         })
         .catch((err) => {
             console.log(err);

--- a/server.js
+++ b/server.js
@@ -19,7 +19,6 @@ async function handleScrapeMeasurements(types, response) {
     await scraper.scrape(types)
         .then(async dataArray => {
             // Here we can access the scraped data from BLUME.
-            console.log(dataArray)
             response.json(dataArray)
             await Promise.resolve();
         }, async err => {

--- a/server.js
+++ b/server.js
@@ -9,70 +9,73 @@ const app = express();
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
-const asyncMiddleware = fn =>
-    (req, res, next) => {
-        Promise.resolve(fn(req, res, next))
-            .catch(next);
-    };
+const asyncMiddleware = fn => (req, res, next) => {
+    Promise
+        .resolve(fn(req, res, next))
+        .catch(next);
+};
+
+async function handleScrapeMeasurements(types, response) {
+    await scraper.scrape(types)
+        .then(async dataArray => {
+            // Here we can access the scraped data from BLUME.
+            console.log(dataArray)
+            response.json(dataArray)
+            await Promise.resolve();
+        }, async err => {
+            console.log(err);
+            response.sendStatus(500);
+            await Promise.reject(err);
+        });
+}
+
+app.get('/api/v1/latestMeasurement_PM10', asyncMiddleware(async (req, res, next) => {    
+    handleScrapeMeasurements(["PM10"], res).catch(() => {});
+}));
+
+app.get('/api/v1/latestMeasurement_NO', asyncMiddleware(async (req, res, next) => {    
+    handleScrapeMeasurements(["NO"], res).catch(() => {});
+}));
+
+app.get('/api/v1/latestMeasurement_NO2', asyncMiddleware(async (req, res, next) => {    
+    handleScrapeMeasurements(["NO₂"], res).catch(() => {});
+}));
+
+app.get('/api/v1/latestMeasurement_NOX', asyncMiddleware(async (req, res, next) => {    
+    handleScrapeMeasurements(["NOx"], res).catch(() => {});
+}));
+
+app.get('/api/v1/latestMeasurement_O3', asyncMiddleware(async (req, res, next) => {    
+    handleScrapeMeasurements(["O₃"], res).catch(() => {});
+}));
+
+app.get('/api/v1/latestMeasurement_CO', asyncMiddleware(async (req, res, next) => {    
+    handleScrapeMeasurements(["CO"], res).catch(() => {});
+}));
+
+app.get('/api/v1/latestMeasurement_SO2', asyncMiddleware(async (req, res, next) => {    
+    handleScrapeMeasurements(["SO₂"], res).catch(() => {});
+}));
+
+app.get('/api/v1/latestMeasurement_CHB', asyncMiddleware(async (req, res, next) => {    
+    handleScrapeMeasurements(["CHB"], res).catch(() => {});
+}));
+
+app.get('/api/v1/latestMeasurement_CHT', asyncMiddleware(async (req, res, next) => {    
+    handleScrapeMeasurements(["CHT"], res).catch(() => {}); 
+}));
 
 app.get('/api/v1/latestMeasurement', asyncMiddleware(async (req, res, next) => {
-    var parameters = [];
-    if(req.query.type !== undefined) {
-         //DO SOMEHTING
-         parameters = req.query.type.split(',');
+    // Generic method takind url query parameters
+    var requestedTypes = [];
+    if (req.query.type !== undefined) {
+        requestedTypes = req.query.type.split(',');
     }
-
-    res.json(req.query.type);
-    await scraper.scrape(parameters).then(async data => {
-        // Here we can access the scraped data from BLUME.
-         console.log(data);
-        /* For every measuring point (Messstaion) there is a timestamp, the coordinated, and measurements. For the API we need to combine all the measurements for one measurement type (e.g. PM10) and format it so it looks like this: 
-        [
-            {
-                timestamp: ...,
-                latitude: ...,
-                longitude: ...,
-                measurement: ...(number)
-            },
-            {
-                timestamp: ...,
-                latitude: ...,
-                longitude: ...,
-                measurement: ...(number)
-            },
-            .
-            .
-            .
-        ]
-        I already added one endpoint above. Just add more endpoints for the other measurement types and send the corresponding data :)
-        */
-    });
+    
+    handleScrapeMeasurements(requestedTypes, res).catch(() => {});
 }));
 
 app.listen(port, asyncMiddleware(async (req, res) => {
-    //console.log(`Listening on port ${port}`);
-    await scraper.scrape([]).then(async data => {
-        // Here we can access the scraped data from BLUME.
-         //console.log(data);
-        /* For every measuring point (Messstaion) there is a timestamp, the coordinated, and measurements. For the API we need to combine all the measurements for one measurement type (e.g. PM10) and format it so it looks like this: 
-        [
-            {
-                timestamp: ...,
-                latitude: ...,
-                longitude: ...,
-                measurement: ...(number)
-            },
-            {
-                timestamp: ...,
-                latitude: ...,
-                longitude: ...,
-                measurement: ...(number)
-            },
-            .
-            .
-            .
-        ]
-        I already added one endpoint above. Just add more endpoints for the other measurement types and send the corresponding data :)
-        */
-    });
+    console.log(`Listening on port ${port}`);
+    handleScrapeMeasurements([], res).catch(() => {});
 }));

--- a/server.js
+++ b/server.js
@@ -15,15 +15,45 @@ const asyncMiddleware = fn =>
             .catch(next);
     };
 
-app.get('/api/v1/latestMeasurement_PM10', asyncMiddleware(async (req, res) => {
-    res.json('send Data');
+app.get('/api/v1/latestMeasurement', asyncMiddleware(async (req, res, next) => {
+    var parameters = [];
+    if(req.query.type !== undefined) {
+         //DO SOMEHTING
+         parameters = req.query.type.split(',');
+    }
+
+    res.json(req.query.type);
+    await scraper.scrape(parameters).then(async data => {
+        // Here we can access the scraped data from BLUME.
+         console.log(data);
+        /* For every measuring point (Messstaion) there is a timestamp, the coordinated, and measurements. For the API we need to combine all the measurements for one measurement type (e.g. PM10) and format it so it looks like this: 
+        [
+            {
+                timestamp: ...,
+                latitude: ...,
+                longitude: ...,
+                measurement: ...(number)
+            },
+            {
+                timestamp: ...,
+                latitude: ...,
+                longitude: ...,
+                measurement: ...(number)
+            },
+            .
+            .
+            .
+        ]
+        I already added one endpoint above. Just add more endpoints for the other measurement types and send the corresponding data :)
+        */
+    });
 }));
 
 app.listen(port, asyncMiddleware(async (req, res) => {
-    console.log(`Listening on port ${port}`);
-    await scraper.scrape().then(async data => {
+    //console.log(`Listening on port ${port}`);
+    await scraper.scrape([]).then(async data => {
         // Here we can access the scraped data from BLUME.
-        // console.log(data);
+         //console.log(data);
         /* For every measuring point (Messstaion) there is a timestamp, the coordinated, and measurements. For the API we need to combine all the measurements for one measurement type (e.g. PM10) and format it so it looks like this: 
         [
             {

--- a/server.js
+++ b/server.js
@@ -66,7 +66,7 @@ app.get('/api/v1/latestMeasurement_CHT', asyncMiddleware(async (req, res, next) 
 }));
 
 app.get('/api/v1/latestMeasurement', asyncMiddleware(async (req, res, next) => {
-    // Generic method takind url query parameters
+    // Generic method taking url query parameters
     var requestedTypes = [];
     if (req.query.type !== undefined) {
         requestedTypes = req.query.type.split(',');


### PR DESCRIPTION
* Refactors scrape method of Luftqualität-Scraper to take unit arguments
* Add GET latestMeasurement EP which takes optional single or array (comma separated) ?type query parameter

Unknown or empty unit types result in 'null' value for unit@station being passed back to the caller